### PR TITLE
Add reading a set of bits as a new stream

### DIFF
--- a/bit-buffer.js
+++ b/bit-buffer.js
@@ -306,8 +306,16 @@ var BitStream = function (source, byteOffset, byteLength) {
 	}
 
 	this._index = 0;
+	this._startIndex = 0;
 	this.length = this._view.byteLength * 8;
 };
+
+Object.defineProperty(BitStream.prototype, 'index', {
+	get: function () { return this._index - this._startIndex },
+	set: function (val) { this._index = val + this._startIndex },
+	enumerable: true,
+	configurable: true
+});
 
 Object.defineProperty(BitStream.prototype, 'byteIndex', {
 	// Ceil the returned value, over compensating for the amount of
@@ -378,6 +386,7 @@ BitStream.prototype.writeUTF8String = function (string, bytes) {
 };
 BitStream.prototype.readBitStream = function(bitLength) {
 	var slice = new BitStream(this._view);
+	slice._startIndex = this._index;
 	slice._index = this._index;
 	slice.length = slice._index + bitLength;
 	this._index += bitLength;

--- a/bit-buffer.js
+++ b/bit-buffer.js
@@ -180,7 +180,7 @@ BitView.prototype.setFloat64 = function (offset, value) {
  **********************************************************/
 var reader = function (name, size) {
 	return function () {
-		if (this._index + size > this.length) {
+		if (this._index + size > this._length) {
 			throw new Error('Trying to read past the end of the stream');
 		}
 		var val = this._view[name](this._index);
@@ -210,7 +210,7 @@ function readString(stream, bytes, utf8) {
 	var append = true;
 	var fixedLength = !!bytes;
 	if (!bytes) {
-		bytes = Math.floor((stream.length - stream._index) / 8);
+		bytes = Math.floor((stream._length - stream._index) / 8);
 	}
 
 	// Read while we still have space available, or until we've
@@ -307,13 +307,20 @@ var BitStream = function (source, byteOffset, byteLength) {
 
 	this._index = 0;
 	this._startIndex = 0;
-	this.length = this._view.byteLength * 8;
+	this._length = this._view.byteLength * 8;
 };
 
 Object.defineProperty(BitStream.prototype, 'index', {
 	get: function () { return this._index - this._startIndex },
 	set: function (val) { this._index = val + this._startIndex },
 	enumerable: true,
+	configurable: true
+});
+
+Object.defineProperty(BitStream.prototype, 'length', {
+	get: function () {return this._length - this._startIndex},
+	set: function (val) {this._length = val + this._startIndex},
+	enumerable  : true,
 	configurable: true
 });
 
@@ -388,7 +395,7 @@ BitStream.prototype.readBitStream = function(bitLength) {
 	var slice = new BitStream(this._view);
 	slice._startIndex = this._index;
 	slice._index = this._index;
-	slice.length = slice._index + bitLength;
+	slice.length = bitLength;
 	this._index += bitLength;
 	return slice;
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "description": "Bit-level reads and writes for ArrayBuffers",
   "main": "bit-buffer.js",
+  "types": "./bit-buffer.d.ts",
   "directories": {
     "test": "test"
   },

--- a/test.js
+++ b/test.js
@@ -258,6 +258,8 @@ suite('BitBuffer', function () {
 		bsr.readBits(3); //offset
 		var slice = bsr.readBitStream(8);
 		assert.equal(slice.readBits(6), 0x3E); //0b111110
+		assert.equal(9, slice._index);
+		assert.equal(6, slice.index);
 
 		assert.equal(bsr._index, 11);
 	});

--- a/test.js
+++ b/test.js
@@ -260,6 +260,7 @@ suite('BitBuffer', function () {
 		assert.equal(slice.readBits(6), 0x3E); //0b111110
 		assert.equal(9, slice._index);
 		assert.equal(6, slice.index);
+		assert.equal(8, slice.length);
 
 		assert.equal(bsr._index, 11);
 	});

--- a/test.js
+++ b/test.js
@@ -251,4 +251,31 @@ suite('BitBuffer', function () {
 		assert.equal(str, bsr.readUTF8String());
 		assert.equal(bsr.byteIndex, bytes.length + 1);
 	});
+
+	test('readBitStream', function () {
+		bsw.writeBits(0xF0, 8); //0b11110000
+		bsw.writeBits(0xF1, 8); //0b11110001
+		bsr.readBits(3); //offset
+		var slice = bsr.readBitStream(8);
+		assert.equal(slice.readBits(6), 0x3E); //0b111110
+
+		assert.equal(bsr._index, 11);
+	});
+
+	test('readBitStream overflow', function () {
+		bsw.writeBits(0xF0, 8); //0b11110000
+		bsw.writeBits(0xF1, 8); //0b11110001
+		bsr.readBits(3); //offset
+		var slice = bsr.readBitStream(4);
+
+		var exception = false;
+
+		try {
+			slice.readUint8();
+		} catch (e) {
+			exception = true;
+		}
+
+		assert(exception);
+	});
 });


### PR DESCRIPTION
- Adds explicit handling of the stream length to BitStream
- Allow "reading" a set of bits into a new BitStream

the new BitStream reuses the same BitView as datastore, but keeps track of it's own index and length to make it function independent from the parent stream