### PR TITLE
Add read and write support for big-endian byte order

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ BitBuffer provides two objects, `BitView` and `BitStream`. `BitView` is a wrappe
 bb.buffer  // Underlying ArrayBuffer.
 ```
 
+```javascript
+bb.bigEndian = true; // Switch to big endian (default is little)
+```
+
 ### Methods
 
 #### BitView(buffer, optional byteOffset, optional byteLength)
@@ -75,6 +79,10 @@ bb.bitsLeft; // The number of bits left in the stream
 ```javascript
 bb.index; // Get the current index in bits
 bb.index = 0// Set the current index in bits
+```
+
+```javascript
+bb.bigEndian = true; // Switch to big endian (default is little)
 ```
 
 ### Methods

--- a/bit-buffer.js
+++ b/bit-buffer.js
@@ -64,19 +64,20 @@ BitView.prototype.getBits = function (offset, bits, signed) {
 		// the max number of bits we can read from the current byte
 		var read = Math.min(remaining, 8 - bitOffset);
 
+		var mask, readBits;
 		if (this.bigEndian) {
 			// create a mask with the correct bit width
-			var mask = ~(0xFF << read);
+			mask = ~(0xFF << read);
 			// shift the bits we want to the start of the byte and mask of the rest
-			var readBits = (currentByte >> (8 - read - bitOffset)) & mask;
+			readBits = (currentByte >> (8 - read - bitOffset)) & mask;
 
 			value <<= read;
 			value |= readBits;
 		} else {
 			// create a mask with the correct bit width
-			var mask = ~(0xFF << read);
+			mask = ~(0xFF << read);
 			// shift the bits we want to the start of the byte and mask off the rest
-			var readBits = (currentByte >> bitOffset) & mask;
+			readBits = (currentByte >> bitOffset) & mask;
 
 			value |= readBits << i;
 		}
@@ -112,15 +113,16 @@ BitView.prototype.setBits = function (offset, value, bits) {
 		var byteOffset = offset >> 3;
 		var wrote = Math.min(remaining, 8 - bitOffset);
 
+		var mask, writeBits, destMask;
 		if (this.bigEndian) {
 			// create a mask with the correct bit width
-			var mask = ~(~0 << wrote);
+			mask = ~(~0 << wrote);
 			// shift the bits we want to the start of the byte and mask of the rest
-			var writeBits = (value >> (bits - i - wrote)) & mask;
+			writeBits = (value >> (bits - i - wrote)) & mask;
 
 			var destShift = 8 - bitOffset - wrote;
 			// destination mask to zero all the bits we're changing first
-			var destMask = ~(mask << destShift);
+			destMask = ~(mask << destShift);
 
 			this._view[byteOffset] =
 				(this._view[byteOffset] & destMask)
@@ -128,13 +130,13 @@ BitView.prototype.setBits = function (offset, value, bits) {
 
 		} else {
 			// create a mask with the correct bit width
-			var mask = ~(0xFF << wrote);
+			mask = ~(0xFF << wrote);
 			// shift the bits we want to the start of the byte and mask of the rest
-			var writeBits = value & mask;
+			writeBits = value & mask;
 			value >>= wrote;
 
 			// destination mask to zero all the bits we're changing first
-			var destMask = ~(mask << bitOffset);
+			destMask = ~(mask << bitOffset);
 
 			this._view[byteOffset] =
 				(this._view[byteOffset] & destMask)


### PR DESCRIPTION
This works both at the byte level (significant byte first) and at the bit level (if reading or writing less than a whole byte), starting from the most significant bit first.

It is meant to supersede PR #5, which only adds read support and doesn't include any tests.

I originally implemented it as callback functions (to avoid the `if` condition in every loop in the read/write functions), however this seemed to add unnecessary complexity.  Instead, I rewrote `setBits()` to work on whole chunks at a time instead of looping once per bit (using the same method as `getBits()`) so the condition checking the endianness will now only run once per *byte* which should be acceptable.  It should also be much faster than before as a result of the rewrite.