### PR TITLE
Add browser compatibility (add to window object)

### DIFF
--- a/bit-buffer.js
+++ b/bit-buffer.js
@@ -498,5 +498,10 @@ else if (typeof module !== 'undefined' && module.exports) {
 		BitStream: BitStream
 	};
 }
+// browser
+else if (typeof window !== 'undefined') {
+    window.BitView = BitView;
+    window.BitStream = BitStream;
+}
 
 }(this));


### PR DESCRIPTION
This gives compatibility for browsers by adding on to the window object
if `define` and `module.exports` isn't available.